### PR TITLE
Trigger initial data fetch on RecentPlays mount

### DIFF
--- a/src/sections/RecentPlays/RecentPlays.tsx
+++ b/src/sections/RecentPlays/RecentPlays.tsx
@@ -75,6 +75,7 @@ export default function RecentPlays() {
 
   // Auto-reload every second
   React.useEffect(() => {
+    setRefresh(prev => prev + 1) // Trigger initial fetch immediately on mount
     const interval = setInterval(() => {
       setRefresh(prev => prev + 1) // Trigger re-render to fetch new data
     }, 1000) // 1000ms = 1 second


### PR DESCRIPTION
Added a call to setRefresh in the RecentPlays useEffect to ensure data is fetched immediately when the component mounts, rather than waiting for the first interval tick.